### PR TITLE
Return code of check_backups_available was not an int, but a string

### DIFF
--- a/check-barman.rb
+++ b/check-barman.rb
@@ -74,8 +74,10 @@ def check_backups_available(server, warning, critical)
     p "No backups available!"
   else
     p "#{count} backups available"
-    nagios_return_value(count, warning, critical)
+    return_code = nagios_return_value(count, warning, critical)
   end
+
+  return_code
 end
 
 def check_last_wal_received(server, warning, critical)


### PR DESCRIPTION
When there are no backups available, the string "No backups available!" would've
been returned instead of the return code, due rubys style of returning variables.