### PR TITLE
Handle invalid argument exception gracefully

### DIFF
--- a/check-barman.rb
+++ b/check-barman.rb
@@ -209,8 +209,14 @@ if ARGV.count == 0
   exit 1
 end
 
-optparse.parse!
-
+begin
+  optparse.parse!
+rescue OptionParser::InvalidArgument
+  puts $!.to_s
+  puts optparse
+  exit 1
+end
+  
 server = options[:server]
 warning = options[:warning]
 critical = options[:critical]


### PR DESCRIPTION
A small change to print a nicer error (rather than a stack trace) when you pass an invalid argument (such as when you misspell the action)